### PR TITLE
change log refinements

### DIFF
--- a/src/components/AddressLinks.vue
+++ b/src/components/AddressLinks.vue
@@ -64,8 +64,8 @@ export default {
   },
   async mounted() {
     this.isLoading = true;
-    this.setLeftNavRoute(`/territories/${this.group}/${this.territoryId}`);
     await this.fetchAddress(this.addressId);
+    this.setLeftNavRoute(this.returnRoute);
     this.isLoading = false;
   },
   computed: {
@@ -92,6 +92,15 @@ export default {
       const state = `${get(this.address, 'state_province', '').trim().replace(/\s+/g, '-')}`;
       return `https://www.fastpeoplesearch.com/address/${addr1}_${city}-${state}`;
     },
+    returnRoute() {
+      const { origin } = this.$route.query;
+      if (origin === 'change-logs') {
+        return '/reports/logs/addresses?fullscreen=true';
+      }
+
+      return `/territories/${this.group}/${this.territoryId}`;
+    },
+
   },
   methods: {
     ...mapActions({

--- a/src/components/AddressMap.vue
+++ b/src/components/AddressMap.vue
@@ -16,7 +16,7 @@
       <v-marker-cluster
         class="marker-cluster"
         ref="markerCluster"
-        v-if="step===3"
+        v-show="step===3"
         :options="{
           maxClusterRadius: 4000,
           zoomToBoundsOnClick: false,

--- a/src/components/ChangeLog.vue
+++ b/src/components/ChangeLog.vue
@@ -1,20 +1,23 @@
 <template>
   <div class="change-log" :class="{ 'text-left': isFullScreen }">
     <div
-      class="d-flex justify-content-between align-items-center pb-0"
+      class="d-flex justify-content-between align-items-center pb-0 text-center"
       :class="{ 'p-3': isFullScreen, 'flex-column': isSingleRecord }">
-      <span
+      <div
         v-if="isSingleRecord"
         :class="{
           small: !isFullScreen,
           lead: isFullScreen,
           'font-weight-bold': isFullScreen
-        }">{{title}}</span>
-      <span
+        }">
+        <div>{{title1}}</div>
+        <div>{{title2}}</div>
+      </div>
+      <div
         :class="{
           small: !isFullScreen,
           lead: isFullScreen,
-        }">{{subtitle}}</span>
+        }">{{subtitle}}</div>
       <b-dropdown v-if="showDateFilter" class="date-filter" right variant="secondary">
         <span slot="button-content">Range: {{selectedRange.text}}</span>
         <b-dropdown-item v-for='(range, index) in dateRanges' :key="index" @click="() => selectRange(range)">
@@ -117,9 +120,14 @@ export default {
       user: 'auth/user',
       storeLogs: 'addresses/logs',
     }),
-    title() {
+    title1() {
       return this.isSingleRecord && this.logs && this.logs.length
         ? `${this.logs[0].address.addr1} ${this.logs[0].address.addr2}`
+        : '';
+    },
+    title2() {
+      return this.isSingleRecord && this.logs && this.logs.length
+        ? `${this.logs[0].address.city}, ${this.logs[0].address.state_province}`
         : '';
     },
     subtitle() {

--- a/src/components/ChangeLog.vue
+++ b/src/components/ChangeLog.vue
@@ -2,8 +2,19 @@
   <div class="change-log" :class="{ 'text-left': isFullScreen }">
     <div
       class="d-flex justify-content-between align-items-center pb-0"
-      :class="{ 'p-3': isFullScreen }">
-      <span :class="{ small: !isFullScreen, lead: isFullScreen }">{{title}}</span>
+      :class="{ 'p-3': isFullScreen, 'flex-column': isSingleRecord }">
+      <span
+        v-if="isSingleRecord"
+        :class="{
+          small: !isFullScreen,
+          lead: isFullScreen,
+          'font-weight-bold': isFullScreen
+        }">{{title}}</span>
+      <span
+        :class="{
+          small: !isFullScreen,
+          lead: isFullScreen,
+        }">{{subtitle}}</span>
       <b-dropdown v-if="showDateFilter" class="date-filter" right variant="secondary">
         <span slot="button-content">Range: {{selectedRange.text}}</span>
         <b-dropdown-item v-for='(range, index) in dateRanges' :key="index" @click="() => selectRange(range)">
@@ -13,13 +24,13 @@
     </div>
     <font-awesome-icon v-if="loading" class="loading text-info text-center w-100 mt-5" icon="circle-notch" :spin="true" />
     <div v-else>
-      <div class="mx-3 mb-3">
-        <b-form-input v-model="keywordFilter" placeholder="Filter" />
+      <div v-if="isFullScreen" class="mx-3 mb-3">
+        <b-form-input v-model="keywordFilter" placeholder="Filter by address, publisher, or territory" />
         <span class="d-block small pt-1 text-right">Count: {{logs.length}}</span>
       </div>
       <b-list-group>
         <b-list-group-item class="pl-3 pr-3" :class="{ small: !isFullScreen }" v-for="log in logs" :key="log.id">
-          <ChangeLogAddressCard :log="log" />
+          <ChangeLogAddressCard :log="log" :is-single-record="isSingleRecord" />
         </b-list-group-item>
         <b-link
           v-if="!isFullScreen"
@@ -107,20 +118,29 @@ export default {
       storeLogs: 'addresses/logs',
     }),
     title() {
-      return 'Recent Updates:';
+      return this.isSingleRecord && this.logs && this.logs.length
+        ? `${this.logs[0].address.addr1} ${this.logs[0].address.addr2}`
+        : '';
+    },
+    subtitle() {
+      return 'Recent Updates';
+    },
+    cleanLogs() {
+      return this.storeLogs.filter(log => !log.address.territory.name.includes('TEST'));
     },
     preview() {
-      return this.storeLogs.slice(0, 3);
+      return this.cleanLogs.slice(0, 3);
     },
     logs() {
       if (this.keywordFilter) {
-        return this.storeLogs.filter(log => this.compareToKeyword(log.address.addr1)
+        return this.cleanLogs.filter(log => this.compareToKeyword(log.address.addr1)
           || this.compareToKeyword(log.address.addr2)
           || this.compareToKeyword(log.publisher.firstname)
-          || this.compareToKeyword(log.publisher.lastname));
+          || this.compareToKeyword(log.publisher.lastname)
+          || this.compareToKeyword(log.address.territory.name));
       }
 
-      return this.isFullScreen ? this.storeLogs : this.preview;
+      return this.isFullScreen ? this.cleanLogs : this.preview;
     },
     isFullScreen() {
       return this.$route.query.fullscreen;
@@ -138,7 +158,7 @@ export default {
       ];
     },
     showDateFilter() {
-      return this.isFullScreen && !this.recordId && !this.publisherId;
+      return this.isFullScreen && !this.isSingleRecord;
     },
     returnRoute() {
       if (this.recordId && this.type === 'addresses') {
@@ -146,6 +166,9 @@ export default {
       }
 
       return '/';
+    },
+    isSingleRecord() {
+      return !!this.recordId || !!this.publisherId;
     },
   },
   watch: {

--- a/src/components/ChangeLogAddressCard.vue
+++ b/src/components/ChangeLogAddressCard.vue
@@ -2,10 +2,16 @@
   <div class="change-log-address-card d-flex flex-column justify-content-between">
     <div class="d-flex justify-content-between pb-3">
       <div>
-        <b-link :to="`/territories/${group}/${territoryId}/addresses/${log.address.id}/edit?origin=change-logs`">
+        <b-link
+          v-if="!isSingleRecord"
+          :to="`/territories/${group}/${territoryId}/addresses/${log.address.id}/detail?origin=${$route.name}`">
           <div>{{log.address.addr1}} {{log.address.addr2}}</div>
           <div>{{log.address.city}} {{log.address.state_province}} {{log.address.postal_code}}</div>
         </b-link>
+        <div v-else>
+          <div>{{log.address.addr1}} {{log.address.addr2}}</div>
+          <div>{{log.address.city}} {{log.address.state_province}} {{log.address.postal_code}}</div>
+        </div>
       </div>
       <div class="text-right">
         <div>{{log.address.territory.name}}</div>
@@ -33,7 +39,7 @@ import Change from './Change';
 
 export default {
   name: 'ChangeLogAddressCard',
-  props: ['log'],
+  props: ['log', 'isSingleRecord'],
   components: {
     Change,
   },

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -2,7 +2,7 @@
   <b-container class="dashboard lead">
     <h3 v-if="!isAuthenticated">Welcome to Foreign Field</h3>
     <Auth v-if="!isAuthenticated"></Auth>
-    <b-row v-else class="main">
+    <b-row v-else class="main justify-content-center">
       <div class="new-message bg-secondary text-dark align-items-center pt-2 pb-2 w-100 text-white"
       v-show='msgBoxOpen && !isPWA'>
         <div class="message text-left col-10">
@@ -14,7 +14,7 @@
           </b-button>
         </div>
       </div>
-      <div class="col-sm-12">
+      <div class="col-sm-12 mb-3">
         <h3 class="align-items-center d-flex justify-content-center">
           <img class="logo pr-5" :src="require('../assets/wheat-x.png')" />
           <span class="title w-100">Dashboard</span>
@@ -35,7 +35,7 @@
           </b-button>
         </b-button-group>
       </div>
-      <div v-if="!loading" class="col-sm-12 col-md-6 pt-3 pb-3">
+      <div v-if="!loading" class="panel col-sm-12 col-md-5 pt-3 pb-3 border-info m-2">
         <span v-if="!(territories && territories.length)" class="text-center">I have no territories checked out.</span>
         <div v-else class="text-left">
           <span class="small">Territories I've checked out:</span>
@@ -46,7 +46,7 @@
           </b-list-group>
         </div>
       </div>
-      <div v-if="!loading" class="col-sm-12 col-md-6 text-left pt-3 pb-3">
+      <div v-if="!loading" class="panel col-sm-12 col-md-5 text-left pt-3 pb-3 border-info m-2">
         <span class="small">Other territories I've recently seen:</span>
         <div v-if="seenTerritories.length">
           <b-list-group>
@@ -64,10 +64,10 @@
           </b-list-group>
         </div>
       </div>
-      <div v-if="!loading && canManage" class="text-left pt-3 pb-3 col-sm-12 col-md-6">
+      <div v-if="!loading && canManage" class="panel text-left pt-3 pb-3 col-sm-12 col-md-5 border-info m-2">
         <ChangeLog :type="'addresses'" :fullscreen="false" />
       </div>
-      <div v-if="!loading && canWrite" class="text-left pt-3 pb-3 scol-sm-12 col-md-6">
+      <div v-if="!loading && canWrite" class="panel text-left pt-3 pb-3 scol-sm-12 col-md-5 border-info m-2">
         <Reports />
       </div>
     </b-row>
@@ -150,7 +150,7 @@ export default {
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
-<style lang="scss">
+<style lang="scss" scoped>
 h3 {
   margin: 40px 0 0;
 }
@@ -183,6 +183,10 @@ router-link {
 }
 .firebaseui-list-item {
   width: 100%;
+}
+.panel {
+  border-radius: 10px;
+  border-style: double;
 }
 
 </style>


### PR DESCRIPTION
follow-up refinement to Change Log filters:

1. fixes some navigation back button issues
2. disables address link when change log is already looking at a single address
3. adds address info to header
4. adds territory name to keyword search
5. filters out "TEST" territories
6. styling changes to Welcome page