### PR TITLE
Territories and group enhancements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
       <b-alert variant="success" :show="isCampaignMode">
         <font-awesome-icon icon="bolt" /> CAMPAIGN MODE
       </b-alert>
-      <router-view class="view"></router-view>
+      <router-view class="view" :key="key"></router-view>
     </div>
   </div>
 </template>
@@ -28,6 +28,9 @@ export default {
     }),
     isCampaignMode() {
       return !!get(this.user, 'congregation.campaign') || false;
+    },
+    key() {
+      return `${this.$route.name}-${JSON.stringify(this.$route.params)}`;
     },
   },
 };

--- a/src/components/ActivityHistory.vue
+++ b/src/components/ActivityHistory.vue
@@ -57,7 +57,7 @@ import ActivityButton from './ActivityButton';
 
 export default {
   name: 'ActivityHistory',
-  props: ['group', 'territoryId', 'addressId', 'checkoutId'],
+  props: ['territoryId', 'addressId', 'checkoutId'],
   components: {
     Loading,
     BIconPlus,
@@ -74,7 +74,7 @@ export default {
     };
   },
   async mounted() {
-    this.setLeftNavRoute(`/territories/${this.group}/${this.territoryId}`);
+    this.setLeftNavRoute(`/territories/${this.territoryId}`);
     await this.fetchPublishers(this.congId);
     await this.fetch();
   },

--- a/src/components/AddressCard.vue
+++ b/src/components/AddressCard.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="address-card-container p-2 d-flex align-items-center" :class="{ 'min-height': mode === 'phoneAddress' }">
-    <font-awesome-layers class="ellipsis-v-static text-muted fa-1x" @click="toggleLeftPanel">
+    <font-awesome-layers
+      v-if="mode === 'phoneAddress'"
+      class="ellipsis-v-static text-muted fa-1x"
+      @click="toggleLeftPanel">
       <font-awesome-icon icon="ellipsis-v" class="ml-0"></font-awesome-icon>
     </font-awesome-layers>
     <div class="w-100">
@@ -9,7 +12,7 @@
         <div v-if="mode==='phoneAddress'" class="col-9 pb-2">
           <b-link
             class="w-100"
-            :to="`/territories/${territory.group_code}/${territory.id}/addresses/${address.id}/detail?origin=phone`">
+            :to="`/territories/${territory.id}/addresses/${address.id}/detail?origin=phone`">
             <div class="address text-primary font-weight-bold" :class="{ 'phone-address': mode === 'phoneAddress' }">
               {{address.addr1}} {{address.addr2}}
             </div>
@@ -21,7 +24,7 @@
         <div v-else class="address col-9 flex-column pt-2 pb-4">
           <div>
             <h5 class="mb-0">
-              <b-link :to="`/territories/${group}/${territoryId}/addresses/${address.id}/detail`">
+              <b-link :to="`/territories/${territoryId}/addresses/${address.id}/detail`">
                 {{address.addr1}}
               </b-link>&nbsp;
             </h5>
@@ -80,7 +83,7 @@ import { format as formatPhone } from '../utils/phone';
 
 export default {
   name: 'AddressCard',
-  props: ['address', 'territoryId', 'group', 'incomingResponse', 'revealed', 'index', 'mode', 'disabled'],
+  props: ['address', 'territoryId', 'incomingResponse', 'revealed', 'index', 'mode', 'disabled'],
   components: {
     AddressLinks,
     ActivityButton,

--- a/src/components/AddressForm.vue
+++ b/src/components/AddressForm.vue
@@ -71,7 +71,7 @@
         <b-list-group>
           <b-list-group-item v-for="(search, index) in searchedAddresses" :key="index">
             {{search.addr1}} {{search.addr2}} {{search.city}} {{search.state_province}} {{search.postal_code}}
-            <b-link :to="`/territories/${search.territory.group_code}/${search.territory.id}`">
+            <b-link :to="`/territories/${search.territory.id}`">
               Edit
             </b-link>
           </b-list-group-item>
@@ -108,7 +108,7 @@
           <span v-if="mode === 'add'">the addition of this new address.</span>
           <span v-if="mode === 'edit'">this address update.</span>
         </p>
-        <b-button v-if="canManage" variant="info" :to="`/territories/${territory.group_code}/${territory.id}/optimize`">
+        <b-button v-if="canManage" variant="info" :to="`/territories/${territory.id}/optimize`">
           Optimize
         </b-button>
       </div>
@@ -155,7 +155,7 @@ const requiredAddress = ['addr1', 'city', 'state_province'];
 
 export default {
   name: 'AddressForm',
-  props: ['group', 'territoryId', 'addressId', 'mode', 'phoneId'],
+  props: ['territoryId', 'addressId', 'mode', 'phoneId'],
   components: {
     TheMask,
     AddressMap,
@@ -344,8 +344,8 @@ export default {
       const { origin = '' } = this.$route.query;
       const queryParam = origin ? `?origin=${origin}` : '';
       const addMode = this.mode === Modes.add
-        ? `/territories/${this.group}/${this.territoryId}`
-        : `/territories/${this.group}/${this.territoryId}/addresses/${this.addressId}/detail${queryParam}`;
+        ? `/territories/${this.territoryId}`
+        : `/territories/${this.territoryId}/addresses/${this.addressId}/detail${queryParam}`;
       if (this.$route.name === 'address-new') return '/';
       return addMode;
     },

--- a/src/components/AddressLinks.vue
+++ b/src/components/AddressLinks.vue
@@ -7,7 +7,7 @@
           <div>{{address.addr1}} {{address.addr2}}</div>
           <div>{{address.city}} {{address.state_province}} {{address.postalCode}}</div>
         </div>
-        <b-link class="pr-4" :to="`/territories/${group}/${territoryId}/addresses/${address.id}/edit${queryParamOrigin}`">
+        <b-link class="pr-4" :to="`/territories/${territoryId}/addresses/${address.id}/edit${queryParamOrigin}`">
           <font-awesome-icon class="button" icon="edit"></font-awesome-icon>
         </b-link>
       </div>
@@ -34,19 +34,20 @@
           411.com
         </b-list-group-item>
         <b-list-group-item class="lead p-4 font-weight-bold w-auto" variant="dark"
-          :to="`/territories/${group}/${territoryId}/addresses/${address.id}/history`">
+          :to="`/territories/${territoryId}/addresses/${address.id}/history`">
           <font-awesome-icon icon="history"></font-awesome-icon>&nbsp;
           Activity History
         </b-list-group-item>
         <b-list-group-item v-if="canWrite" class="lead p-4 font-weight-bold w-auto" variant="danger"
-          :to="`/territories/${group}/${territoryId}/addresses/${address.id}/logs?fullscreen=true`">
+          :to="`/territories/${territoryId}/addresses/${address.id}/logs?fullscreen=true`">
           <font-awesome-icon icon="archive"></font-awesome-icon>&nbsp;
           Address Change Log
         </b-list-group-item>
         <b-list-group-item
-          class="lead p-4 font-weight-bold w-auto"
-          :to="`/territories/${group}/${territoryId}/${$route.query.origin || ''}`"
-          variant="light">
+          class="lead p-4 font-weight-bold w-100"
+          @click="() => $router.go(-1)"
+          variant="light"
+          button>
           Cancel
         </b-list-group-item>
       </b-list-group>
@@ -61,7 +62,7 @@ import Loading from './Loading';
 
 export default {
   name: 'AddressLinks',
-  props: ['addressId', 'group', 'territoryId'],
+  props: ['addressId', 'territoryId'],
   components: {
     Loading,
   },
@@ -72,7 +73,6 @@ export default {
   },
   async mounted() {
     this.isLoading = true;
-    this.setLeftNavRoute(this.returnRoute);
     if (this.token) {
       await this.fetchAddress({ addressId: this.addressId });
     }
@@ -112,7 +112,7 @@ export default {
         return '/';
       }
 
-      return `/territories/${this.group}/${this.territoryId}/${origin}`;
+      return `/territories/${this.territoryId}/${origin}`;
     },
     queryParamOrigin() {
       const { origin = '' } = this.$route.query;
@@ -123,7 +123,6 @@ export default {
   methods: {
     ...mapActions({
       fetchAddress: 'address/fetchAddress',
-      setLeftNavRoute: 'auth/setLeftNavRoute',
     }),
   },
 };

--- a/src/components/AddressLinks.vue
+++ b/src/components/AddressLinks.vue
@@ -45,9 +45,8 @@
         </b-list-group-item>
         <b-list-group-item
           class="lead p-4 font-weight-bold w-100"
-          @click="() => $router.go(-1)"
-          variant="light"
-          button>
+          :to="`/territories/${territoryId}/${$route.query.origin || ''}`"
+          variant="light">
           Cancel
         </b-list-group-item>
       </b-list-group>

--- a/src/components/ChangeLogAddressCard.vue
+++ b/src/components/ChangeLogAddressCard.vue
@@ -5,12 +5,12 @@
         <div v-if="!isSingleRecord">
           <b-link
             v-if="log.address.type === 'Phone'"
-            :to="`/territories/${group}/${territoryId}/addresses/${log.address.parent_id}/detail?origin=${$route.name}`">
+            :to="`/territories/${territoryId}/addresses/${log.address.parent_id}/detail?origin=${$route.name}`">
             <div>{{formatPhone(log.address.phone)}}</div>
           </b-link>
           <b-link
             v-else
-            :to="`/territories/${group}/${territoryId}/addresses/${log.address.id}/detail?origin=${$route.name}`">
+            :to="`/territories/${territoryId}/addresses/${log.address.id}/detail?origin=${$route.name}`">
             <div>{{log.address.addr1}} {{log.address.addr2}}</div>
             <div>{{log.address.city}} {{log.address.state_province}} {{log.address.postal_code}}</div>
           </b-link>

--- a/src/components/CheckoutModal.vue
+++ b/src/components/CheckoutModal.vue
@@ -18,7 +18,7 @@ import { mapGetters, mapActions } from 'vuex';
 
 export default {
   name: 'CheckoutModal',
-  props: ['territory', 'fetch'],
+  props: ['territory'],
   data() {
     return {
       selectedPublisher: { name: 'me' },
@@ -50,7 +50,7 @@ export default {
         username: this.user.username,
       });
 
-      this.$router.push(`/territories/${this.group}/${this.territory.id}`);
+      this.$router.push(`/territories/${this.territory.id}`);
     },
   },
 

--- a/src/components/Masthead.vue
+++ b/src/components/Masthead.vue
@@ -18,11 +18,7 @@
         <b-collapse is-nav id="nav_dropdown_collapse" :class="{ 'show d-block': isDesktop }">
           <b-navbar-nav>
             <b-nav-item to="/">Home</b-nav-item>
-            <b-nav-item-dropdown v-if="canWrite" class="group-codes" text="Territories">
-              <b-dropdown-item v-for="group in groupCodes" :key="group" :to="`/territories/${group}`" class="m-0 w-100">
-                <font-awesome-icon icon="check" v-if="group === groupCode" /> {{group}}
-              </b-dropdown-item>
-            </b-nav-item-dropdown>
+            <b-nav-item v-if="canWrite" to="/territories/ALL">Territories</b-nav-item>
             <b-nav-item
               v-if="canWrite && matchingRouteNames.includes('territory')"
               :to="`/territories/${territory.group_code}/${territory.id}/optimize`">

--- a/src/components/Masthead.vue
+++ b/src/components/Masthead.vue
@@ -18,10 +18,10 @@
         <b-collapse is-nav id="nav_dropdown_collapse" :class="{ 'show d-block': isDesktop }">
           <b-navbar-nav>
             <b-nav-item to="/">Home</b-nav-item>
-            <b-nav-item v-if="canWrite" to="/territories/ALL">Territories</b-nav-item>
+            <b-nav-item v-if="canWrite" :to="`/groups/${groupCode}`">Territories</b-nav-item>
             <b-nav-item
               v-if="canWrite && matchingRouteNames.includes('territory')"
-              :to="`/territories/${territory.group_code}/${territory.id}/optimize`">
+              :to="`/territories/${territory.id}/optimize`">
               Optimize
             </b-nav-item>
             <b-nav-item v-if="canRead" :to="`/dnc/${user.congregation && user.congregation.id}`">DNC</b-nav-item>
@@ -59,16 +59,8 @@ export default {
   components: {
     VuePullRefresh,
   },
-  watch: {
-    $route(to) {
-      if (to.params.group) {
-        this.groupCode = to.params.group;
-      }
-    },
-  },
   data() {
     return {
-      groupCode: this.$route.params.group,
       permissions: {
         territories: ['Admin', 'TS', 'GO', 'SO'],
       },
@@ -272,6 +264,9 @@ export default {
     },
     isCampaignMode() {
       return get(this.user, 'congregation.campaign') || false;
+    },
+    groupCode() {
+      return get(this.territory, 'group_code') || (this.groupCodes && this.groupCodes.length && this.groupCodes[0]) || 'ALL';
     },
   },
 };

--- a/src/components/MyTerritory.vue
+++ b/src/components/MyTerritory.vue
@@ -16,6 +16,7 @@
 </template>
 <script>
 import { mapActions } from 'vuex';
+import get from 'lodash/get';
 import format from 'date-fns/format';
 import formatDistance from 'date-fns/formatDistance';
 
@@ -29,7 +30,7 @@ export default {
       return format(new Date(date), 'MM/dd/yyyy');
     },
     url(terr) {
-      return `/territories/${terr.group_code}/${terr.id}`;
+      return `/territories/${terr.id}`;
     },
   },
   computed: {
@@ -49,7 +50,7 @@ export default {
       return formatDistance(new Date(this.territory.lastVisited), new Date(), { addSuffix: true });
     },
     firstCity() {
-      const cityArray = this.territory.city.split(',');
+      const cityArray = (get(this.territory, 'city') || '').split(',');
       return cityArray.length && cityArray[0];
     },
   },

--- a/src/components/Optimize.vue
+++ b/src/components/Optimize.vue
@@ -136,7 +136,7 @@ export default {
     };
   },
   async mounted() {
-    this.setLeftNavRoute(`/territories/${this.group}/${this.id}`);
+    this.setLeftNavRoute(`/territories/${this.id}`);
     await this.getTerritory({ id: this.id });
     this.reset();
   },

--- a/src/components/PhoneAddressCard.vue
+++ b/src/components/PhoneAddressCard.vue
@@ -19,7 +19,6 @@
               :class="{ 'border-warning active': isActiveAddress(item.id) }"
               :address="item"
               :territoryId="territory.id"
-              :group="territory.group_code"
               :incomingResponse="item.lastActivity"
               :revealed="revealed"
               :disabled="disabled"
@@ -335,7 +334,7 @@ export default {
             domProps: {
               innerHTML:
               `This number already exists in territory
-              <b-link :to="/territories/${terr.group_code}/${terr.id}">
+              <b-link :to="/territories/${terr.id}">
                 ${terr.name}
               </b-link>`,
             },

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -8,11 +8,11 @@
         @click="search">
       </font-awesome-icon>
     </div>
-    <div class="d-flex justify-content-between">
-      <b-check v-model="exclude" v-show="allowExclude && !!keywordFilter" class="w-25 text-left">
+    <div class="d-flex justify-content-end">
+      <b-check v-model="exclude" v-show="allowExclude && !!keywordFilter" class="w-50 text-left">
         <span class="small">Exclude Filter</span>
       </b-check>
-      <span v-if="results" class="d-block small pt-1 text-right w-100">Count: {{results.length}}</span>
+      <span v-if="results" class="d-block small pt-1 text-right w-50">Count: {{results.length}}</span>
     </div>
   </div>
 </template>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -8,20 +8,26 @@
         @click="search">
       </font-awesome-icon>
     </div>
-    <span v-if="results" class="d-block small pt-1 text-right">Count: {{results.length}}</span>
+    <div class="d-flex justify-content-between">
+      <b-check v-model="exclude" v-show="allowExclude && !!keywordFilter" class="w-25 text-left">
+        <span class="small">Exclude Filter</span>
+      </b-check>
+      <span v-if="results" class="d-block small pt-1 text-right w-100">Count: {{results.length}}</span>
+    </div>
   </div>
 </template>
 <script>
 export default {
-  props: ['searchText', 'results'],
+  props: ['searchText', 'results', 'allowExclude'],
   data() {
     return {
       keywordFilter: '',
+      exclude: false,
     };
   },
   methods: {
     search() {
-      this.$emit('on-click', this.keywordFilter);
+      this.$emit('on-click', this.keywordFilter, this.exclude);
     },
     keydown(e) {
       if (e.keyCode === 13) {
@@ -31,7 +37,10 @@ export default {
   },
   watch: {
     keywordFilter() {
-      this.$emit('on-change', this.keywordFilter);
+      this.$emit('on-change', this.keywordFilter, this.exclude);
+    },
+    exclude() {
+      this.$emit('on-change', this.keywordFilter, this.exclude);
     },
   },
 };

--- a/src/components/Territory.vue
+++ b/src/components/Territory.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="territory">
-    <Loading v-if="isLoading" />
+    <Loading v-if="territoryIsLoading" />
     <div v-else>
       <header class="w-100 px-2">
         <div class="w-100">
@@ -22,22 +22,22 @@
             <b-button-group size="sm">
               <b-button
                 variant="outline-info"
-                :to="{ name: 'address-list', params: { group, id } }"
+                :to="{ name: 'address-list', params: { id } }"
                 :pressed="viewMode === 'address-list'">
                 Address
               </b-button>
               <b-button
                 variant="outline-info"
-                :to="{ name: 'phone-list', params: { group, id } }"
+                :to="{ name: 'phone-list', params: { id } }"
                 :pressed="viewMode === 'phone-list'">
                 Phone
               </b-button>
-              <b-button variant="outline-info" :to="`/territories/${group}/${id}/map`" :pressed="viewMode==='map-view'">
+              <b-button variant="outline-info" :to="`/territories/${id}/map`" :pressed="viewMode==='map-view'">
                 Map
               </b-button>
             </b-button-group>
             <b-button-group v-if="viewMode==='map-view'" size="sm">
-              <b-button variant="primary" :to="`/territories/${group}/${id}/optimize`">
+              <b-button variant="primary" :to="`/territories/${id}/optimize`">
                 Optimize
               </b-button>
             </b-button-group>
@@ -49,7 +49,7 @@
               <b-button
                 v-if="canWrite && ['address-list', 'phone-list'].includes(viewMode)"
                 variant="success"
-                :to="`/territories/${group}/${id}/addresses/add`">
+                :to="`/territories/${id}/addresses/add`">
                 <font-awesome-icon icon="plus"></font-awesome-icon> New Address
               </b-button>
             </b-button-group>
@@ -75,13 +75,13 @@ export default {
     TerritoryMap,
     Loading,
   },
-  props: ['group', 'id'],
+  props: ['id'],
   beforeRouteEnter(to, from, next) {
     const { options = defaultOptions } = store.state.auth;
     const name = get(options, 'territory.defaultView');
-    const { group, id } = to.params;
+    const { id } = to.params;
     if (name !== to.name) {
-      next({ name, params: { group, id } });
+      next({ name, params: { id } });
     }
     next();
   },
@@ -135,7 +135,7 @@ export default {
       ownedBy: 'territory/isOwnedByUser',
       options: 'auth/options',
       token: 'auth/token',
-      isLoading: 'territory/isLoading',
+      territoryIsLoading: 'territory/isLoading',
     }),
     isCheckedOut() {
       return (this.territory && this.territory.status && this.territory.status.status === 'Checked Out')
@@ -153,10 +153,12 @@ export default {
     },
     secondaryCities() {
       if (this.cityNames.length > 1 && this.cityNames.length <= 3) {
-        return `also: ${this.cityNames.slice(1).join(',')}`;
+        const scubbedCityNames = this.cityNames.slice(1).filter(c => c && c.trim() === 'null');
+        return scubbedCityNames.length > 1 ? `also: ${this.cityNames.slice(1).join(',')}` : '';
       }
       if (this.cityNames.length > 3) {
-        return `also: ${this.cityNames.length} cities`;
+        const scubbedCityNames = this.cityNames.slice(1).filter(c => c && c.trim() === 'null');
+        return `also: ${scubbedCityNames.length} cities`;
       }
 
       return '';

--- a/src/components/TerritoryAddresses.vue
+++ b/src/components/TerritoryAddresses.vue
@@ -22,7 +22,6 @@
             :address="item"
             :reset="reset"
             :territoryId="id"
-            :group="group"
             :incomingResponse="item.lastActivity"
             :revealed="revealed"
             :disabled="disabled"
@@ -71,14 +70,7 @@ export default {
     Loading,
     SearchBar,
   },
-  props: ['territory', 'group', 'id', 'disabled'],
-  async mounted() {
-    // if (this.canCheckout) {
-    //   this.setLeftNavRoute(`/territories/${this.group}`);
-    // } else {
-    //   this.setLeftNavRoute('/');
-    // }
-  },
+  props: ['territory', 'id', 'disabled'],
   data() {
     return {
       isLoading: true,
@@ -110,7 +102,6 @@ export default {
   methods: {
     ...mapActions({
       resetNHRecords: 'territory/resetNHRecords',
-      setLeftNavRoute: 'auth/setLeftNavRoute',
       setAddress: 'address/setAddress',
       addLog: 'address/addLog',
     }),
@@ -199,20 +190,20 @@ export default {
         return;
       }
       const keyword = _keyword.toLowerCase();
-      const foundAddress = this.territory.addresses.find(a => a.addr1.toLowerCase().includes(keyword)
-        || a.addr2.toLowerCase().includes(keyword)
-        || a.city.toLowerCase().includes(keyword)
-        || a.notes.toLowerCase().includes(keyword));
-
+      const foundAddress = this.territory.addresses.find(a => this.compareToKeyword(
+        keyword,
+        [a.addr1, a.addr2, a.city, a.notes],
+      ));
       this.foundId = foundAddress && foundAddress.id || 0;
-    },
-  },
-  watch: {
-    foundId(value) {
-      const card = this.$refs[`address-${value}`];
+      const card = this.$refs[`address-${this.foundId}`];
       if (card && card.$el) card.$el.scrollIntoView();
     },
-    immediate: true,
+    compareToKeyword(keyword, values) {
+      return values.reduce(
+        (acc, value) => acc || String(value).toLowerCase().includes(keyword.toLowerCase()),
+        false,
+      );
+    },
   },
 };
 </script>

--- a/src/components/TerritoryAddresses.vue
+++ b/src/components/TerritoryAddresses.vue
@@ -73,11 +73,11 @@ export default {
   },
   props: ['territory', 'group', 'id', 'disabled'],
   async mounted() {
-    if (this.canCheckout) {
-      this.setLeftNavRoute(`/territories/${this.group}`);
-    } else {
-      this.setLeftNavRoute('/');
-    }
+    // if (this.canCheckout) {
+    //   this.setLeftNavRoute(`/territories/${this.group}`);
+    // } else {
+    //   this.setLeftNavRoute('/');
+    // }
   },
   data() {
     return {

--- a/src/components/TerritoryCard.vue
+++ b/src/components/TerritoryCard.vue
@@ -2,7 +2,7 @@
   <div class="column">
     <div class="row justify-content-between px-2">
       <div>
-        <b-link :to="`/territories/${groupCode}/${terr.id}`" class="column">
+        <b-link :to="`/territories/${terr.id}`" class="column">
           <h5 class="mb-0">
             {{`${primaryDescription}${territoryDescriptions.length > 1
               ? ` +${territoryDescriptions.length-1}`
@@ -90,7 +90,7 @@ export default {
         });
         this.saving = false;
 
-        this.fetch();
+        await this.fetch();
       }
     },
     async fetchLastWorked(territoryId) {

--- a/src/components/TerritoryCard.vue
+++ b/src/components/TerritoryCard.vue
@@ -36,14 +36,21 @@
     <div class="text-right">
       <hr class="mb-2 mt-2" />
       <div class="assigned-to-info">{{assignedTo}}</div>
-      <div class="last-worked" v-if="terr.lastActivity">Last worked: {{lastWorked}}</div>
-      <div v-else class="loading">
-        <div v-if="terr.lastActivityLoading" class="font-weight-bold m-0 medium">
-          <font-awesome-icon icon="circle-notch" spin></font-awesome-icon>
+      <div class="d-flex justify-content-between">
+        <b-badge class="territory-type" alert :variant="typeFilter(terr.type).variant" v-if="terr.type !== 'Regular'">
+          {{typeFilter(terr.type).text}}
+        </b-badge>
+        <div>
+          <div class="last-worked" v-if="terr.lastActivity">Last worked: {{lastWorked}}</div>
+          <div v-else class="loading">
+            <div v-if="terr.lastActivityLoading" class="font-weight-bold m-0 medium">
+              <font-awesome-icon icon="circle-notch" spin></font-awesome-icon>
+            </div>
+            <b-button v-else class="get-last-activity p-0" variant="link" @click="() => fetchLastWorked(terr.id)">
+              Get last activity
+            </b-button>
+          </div>
         </div>
-        <b-button v-else class="get-last-activity p-0" variant="link" @click="() => fetchLastWorked(terr.id)">
-          Get last activity
-        </b-button>
       </div>
     </div>
   </div>
@@ -54,7 +61,7 @@ import format from 'date-fns/format';
 
 export default {
   name: 'TerritoryCard',
-  props: ['terr', 'groupCode', 'selectTerritory', 'fetch'],
+  props: ['terr', 'groupCode', 'selectTerritory', 'fetch', 'typeFilters'],
   data() {
     return {
       saving: false,
@@ -99,6 +106,9 @@ export default {
       const vuexTerritory = this.territories.find(t => t.id === this.terr.id);
       this.$set(this.terr, 'lastActivity', vuexTerritory.lastActivity);
       this.$set(this.terr, 'lastActivityLoading', false);
+    },
+    typeFilter(type) {
+      return this.typeFilters.find(t => t.value === type) || {};
     },
   },
   computed: {

--- a/src/components/TerritoryMap.vue
+++ b/src/components/TerritoryMap.vue
@@ -51,7 +51,7 @@ export default {
     LControlZoom,
     MapLinks,
   },
-  props: ['group', 'id', 'territory', 'options'],
+  props: ['id', 'territory', 'options'],
   data() {
     return {
       url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
@@ -93,7 +93,7 @@ export default {
     },
   },
   async mounted() {
-    this.setLeftNavRoute(`/territories/${this.group}/${this.id}`);
+    this.setLeftNavRoute(`/territories/${this.id}`);
     if (this.token && !this.territory) {
       await this.getTerritory({ id: this.id });
     }

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,8 +25,17 @@ const routes = [
     name: 'signout', path: '/signout', component: Signout, props: true,
   },
   {
+    name: 'territories',
+    path: '/territories',
+    props: true,
+    meta: {
+      permissions: ['Admin', 'TS', 'GO', 'SO', 'RP-E'],
+    },
+    redirect: '/groups/ALL',
+  },
+  {
     name: 'group',
-    path: '/territories/:groupCode',
+    path: '/groups/:groupCode',
     component: Territories,
     props: true,
     meta: {
@@ -35,7 +44,7 @@ const routes = [
   },
   {
     name: 'territory',
-    path: '/territories/:groupCode/:id',
+    path: '/territories/:id',
     component: Territory,
     props: true,
     meta: {
@@ -65,16 +74,30 @@ const routes = [
       meta: {
         permissions: ['Admin', 'TS', 'SO', 'GO', 'RP', 'RP-E', 'PUB'],
       },
-    }],
-  },
-  {
-    name: 'optimize',
-    path: '/territories/:group/:id/optimize',
-    component: Optimize,
-    props: true,
-    meta: {
-      permissions: ['Admin', 'TS', 'SO', 'GO'],
     },
+    {
+      name: 'optimize',
+      path: 'optimize',
+      component: Optimize,
+      props: true,
+      meta: {
+        permissions: ['Admin', 'TS', 'SO', 'GO'],
+      },
+    },
+    {
+      name: 'territory-group',
+      path: '/territories/:groupCode/:id',
+      props: true,
+      redirect: (to) => {
+        if (to.params.groupCode && Number.isSafeInteger(Number(to.params.id))) {
+          return '/territories/:id';
+        }
+        return '/groups/:groupCode';
+      },
+      meta: {
+        permissions: ['Admin', 'TS', 'GO', 'SO', 'RP-E', 'PUB'],
+      },
+    }],
   },
   {
     name: 'dnc',
@@ -105,7 +128,7 @@ const routes = [
   },
   {
     name: 'address-change-logs',
-    path: '/territories/:group/:territoryId/:type/:recordId/logs',
+    path: '/territories/:territoryId/:type/:recordId/logs',
     component: ChangeLog,
     props: true,
     meta: {
@@ -114,7 +137,7 @@ const routes = [
   },
   {
     name: 'address-links',
-    path: '/territories/:group/:territoryId/addresses/:addressId/detail',
+    path: '/territories/:territoryId/addresses/:addressId/detail',
     component: AddressLinks,
     props: true,
     meta: {
@@ -123,7 +146,7 @@ const routes = [
   },
   {
     name: 'activity-history',
-    path: '/territories/:group/:territoryId/addresses/:addressId/history',
+    path: '/territories/:territoryId/addresses/:addressId/history',
     component: ActivityHistory,
     props: true,
     meta: {
@@ -132,7 +155,7 @@ const routes = [
   },
   {
     name: 'activity-history-checkout',
-    path: '/territories/:group/:territoryId/addresses/:addressId/history/:checkoutId',
+    path: '/territories/:territoryId/addresses/:addressId/history/:checkoutId',
     component: ActivityHistory,
     props: true,
     meta: {
@@ -150,7 +173,7 @@ const routes = [
   },
   {
     name: 'address-new-terr',
-    path: '/territories/:group/:territoryId/addresses/:mode',
+    path: '/territories/:territoryId/addresses/:mode',
     component: AddressForm,
     props: true,
     meta: {
@@ -159,7 +182,7 @@ const routes = [
   },
   {
     name: 'address-edit',
-    path: '/territories/:group/:territoryId/addresses/:addressId/:mode',
+    path: '/territories/:territoryId/addresses/:addressId/:mode',
     component: AddressForm,
     props: true,
     meta: {
@@ -168,7 +191,7 @@ const routes = [
   },
   {
     name: 'phone-new',
-    path: '/territories/:group/:territoryId/addresses/:addressId/phones/:mode',
+    path: '/territories/:territoryId/addresses/:addressId/phones/:mode',
     component: AddressForm,
     props: true,
     meta: {
@@ -177,7 +200,7 @@ const routes = [
   },
   {
     name: 'phone-edit',
-    path: '/territories/:group/:territoryId/addresses/:addressId/phones/:phoneId/:mode',
+    path: '/territories/:territoryId/addresses/:addressId/phones/:phoneId/:mode',
     component: AddressForm,
     props: true,
     meta: {

--- a/src/routes.js
+++ b/src/routes.js
@@ -26,7 +26,7 @@ const routes = [
   },
   {
     name: 'group',
-    path: '/territories/:group',
+    path: '/territories/:groupCode',
     component: Territories,
     props: true,
     meta: {
@@ -35,7 +35,7 @@ const routes = [
   },
   {
     name: 'territory',
-    path: '/territories/:group/:id',
+    path: '/territories/:groupCode/:id',
     component: Territory,
     props: true,
     meta: {

--- a/src/store/modules/territory.js
+++ b/src/store/modules/territory.js
@@ -95,11 +95,11 @@ export const territory = {
       }
     },
     LOADING_TERRITORY_TRUE(state) {
-      state.isLoading = true;
+      Vue.set(state, 'isLoading', true);
       state.territory = { ...initialState.territory };
     },
     LOADING_TERRITORY_FALSE(state) {
-      state.isLoading = false;
+      Vue.set(state, 'isLoading', false);
     },
   },
 
@@ -230,7 +230,6 @@ export const territory = {
         terr.addresses = orderBy(terr.addresses, 'sort');
         commit(SET_TERRITORY, terr);
         commit(GET_TERRITORY_SUCCESS);
-        commit(LOADING_TERRITORY_FALSE);
 
         if (getLastActivity) await dispatch('fetchLastActivities', terr);
       } catch (exception) {
@@ -240,10 +239,11 @@ export const territory = {
       }
     },
 
-    async fetchLastActivities({ dispatch }, terr) {
+    async fetchLastActivities({ commit, dispatch, getters }, terr) {
       for (const address of terr.addresses) {
         for (const phone of address.phones) {
           await dispatch('phone/fetchLastActivity', { phoneId: phone.id }, { root: true });
+          if (getters.isLoading) commit(LOADING_TERRITORY_FALSE);
         }
         await dispatch('address/fetchLastActivity', { addressId: address.id }, { root: true });
       }


### PR DESCRIPTION
1. Add a route key on the main <router-view>.  Route key is a combination of route name and all of its params.
2. Remove unnecessary "group" leg from territory routes.
3. Hide left vertical ellipsis when AddressCard mode is not "phoneAddress".
4. Remove custom "back" button logic in some pages. The natural browser back button behavior appears to be sufficient here.
5. Fix missing Change Log titles in single record mode
6. Convert compareToKeyword to a reduce function.
7. Refactor Territories group selection away from Masthead and into the Territories page.
8. Add a search filter in Territories page.
9. Add an exclude filter in SearchBar.
10. Add a count for each Territory status, along with an overall count.
11. Add an option to see ALL groups in Territories page.
12. Fix loading indicator on Territory page.
13. Remove "null" city names on Territory page.
14. Add legacy /territories/:group/:id route that redirects to new /territories/:id route.
15. Add territory type filter in Territories (Survey/Business)