### PR TITLE
full-blown push updates to single territory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5505,9 +5505,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001059",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001059.tgz",
-      "integrity": "sha512-oOrc+jPJWooKIA0IrNZ5sYlsXc7NP7KLhNWrSGEJhnfSzDvDJ0zd3i6HXsslExY9bbu+x0FQ5C61LcqmPt7bOQ==",
+      "version": "1.0.30001181",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001181.tgz",
+      "integrity": "sha512-m5ul/ARCX50JB8BSNM+oiPmQrR5UmngaQ3QThTTp5HcIIQGP/nPBs82BYLE+tigzm3VW+F4BJIhUyaVtEweelQ==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,9 @@
 <script>
 import { mapGetters, mapActions } from 'vuex';
 import get from 'lodash/get';
+import { channel } from './main';
 import Masthead from './components/Masthead';
+import { AddressStatus } from './store';
 
 export default {
   name: 'app',
@@ -40,6 +42,75 @@ export default {
   },
   async mounted() {
     await this.refresh();
+
+    channel.bind('add-address', (address) => {
+      if (address) {
+        this.addAddress(address);
+      }
+    });
+    channel.bind('update-address', (address) => {
+      if (address && address.status !== AddressStatus.Active) {
+        this.deleteAddress(address);
+      } else {
+        this.updateAddress(address);
+      }
+    });
+    channel.bind('change-address-status', (address) => {
+      if (address && address.status !== AddressStatus.Active) {
+        this.deleteAddress(address);
+      } else {
+        this.updateAddress(address);
+      }
+    });
+    channel.bind('add-phone', (phone) => {
+      if (phone) {
+        this.addPhone(phone);
+      }
+    });
+    channel.bind('update-phone', (phone) => {
+      if (phone && phone.status !== AddressStatus.Active) {
+        this.deletePhone(phone);
+      } else {
+        this.updatePhone(phone);
+      }
+    });
+    channel.bind('change-phone-status', (phone) => {
+      if (phone && phone.status !== AddressStatus.Active) {
+        this.deletePhone(phone);
+      } else {
+        this.updatePhone(phone);
+      }
+    });
+    channel.bind('add-log', (log) => {
+      if (log) {
+        this.setAddressLastActivity({ addressId: log.address_id, lastActivity: log });
+        this.setPhoneLastActivity({ phoneId: log.address_id, lastActivity: log });
+      }
+    });
+    channel.bind('add-note', (args) => {
+      if (args && this.territory) {
+        const { addressId, notes } = args;
+        this.updateAddressNotes({ territoryId: this.territory.id, addressId, notes });
+      }
+    });
+    channel.bind('remove-note', (args) => {
+      if (args && this.territory) {
+        const { addressId, notes } = args;
+        this.updateAddressNotes({ territoryId: this.territory.id, addressId, notes });
+      }
+    });
+    channel.bind('add-phone-tag', (args) => {
+      if (args && this.territory) {
+        const { phoneId, notes } = args;
+        this.updatePhoneNotes({ territoryId: this.territory.id, phoneId, notes });
+      }
+    });
+    channel.bind('remove-phone-tag', (args) => {
+      if (args && this.territory) {
+        const { phoneId, notes } = args;
+        this.updatePhoneNotes({ territoryId: this.territory.id, phoneId, notes });
+      }
+    });
   },
   computed: {
     ...mapGetters({
@@ -47,6 +118,7 @@ export default {
       isDesktop: 'auth/isDesktop',
       user: 'auth/user',
       canWrite: 'auth/canWrite',
+      territory: 'territory/territory',
     }),
     isCampaignMode() {
       return !!get(this.user, 'congregation.campaign') || false;
@@ -65,6 +137,16 @@ export default {
     ...mapActions({
       back: 'auth/back',
       authorize: 'auth/authorize',
+      addAddress: 'territory/addAddress',
+      addPhone: 'territory/addPhone',
+      updateAddress: 'territory/updateAddress',
+      updatePhone: 'territory/updatePhone',
+      deleteAddress: 'territory/deleteAddress',
+      deletePhone: 'territory/deletePhone',
+      updateAddressNotes: 'territory/updateAddressNotes',
+      updatePhoneNotes: 'territory/updatePhoneNotes',
+      setAddressLastActivity: 'territory/setAddressLastActivity',
+      setPhoneLastActivity: 'territory/setPhoneLastActivity',
     }),
     goBack() {
       this.back({ vm: this });

--- a/src/assets/foreign-field-theme.scss
+++ b/src/assets/foreign-field-theme.scss
@@ -17,6 +17,7 @@ html, body { height: 100% }
 }
 .interaction {
   width: 80px;
+  border-radius: 0;
 }
 .page-header {
   top: 52px;

--- a/src/components/PhoneAddressCard.vue
+++ b/src/components/PhoneAddressCard.vue
@@ -316,7 +316,6 @@ export default {
       };
 
       await this.addPhone(phone);
-      this.address.phones.push(this.phone);
       this.newPhone = '';
       this.toggleNoNumberTag({ forceRemove: true });
       this.isAdding = false;
@@ -377,8 +376,6 @@ export default {
       if (response) {
         this.isAddressBusy = true;
         await this.updatePhone({ ...phone, status: AddressStatus.Inactive });
-        const index = this.address.phones.findIndex(p => p.id === phone.id);
-        this.address.phones.splice(index, 1);
         this.isAddressBusy = false;
       }
       this.$set(phone, 'isBusy', false);

--- a/src/components/PhoneWitnessing.vue
+++ b/src/components/PhoneWitnessing.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="phone-witnessing w-100 d-flex flex-row flex-wrap">
-    <SearchBar class="w-100" :search-text="'Search this territory'" @on-click="search" top="176px"></SearchBar>
+    <SearchBar class="w-100" :search-text="'Search this territory'" @on-click="search" top="135px"></SearchBar>
     <PhoneAddressCard
       v-for="(a, index) in territory.addresses" :key="a.id"
       :ref="`phone-address-${a.id}`"
@@ -20,7 +20,6 @@ import get from 'lodash/get';
 import PhoneAddressCard from './PhoneAddressCard';
 import SearchBar from './SearchBar';
 import Loading from './Loading.vue';
-import { channel } from '../main';
 
 const BUTTON_LIST = ['NH', 'HOME', 'PH', 'LW'];
 export default {
@@ -40,24 +39,6 @@ export default {
   },
   props: ['territory', 'id', 'disabled'],
   async mounted() {
-    channel.bind('add-log', async (log) => {
-      if (log && this.territory && this.territory.addresses) {
-        this.setPhoneLastActivity({ phoneId: log.address_id, lastActivity: log });
-      }
-    });
-    channel.bind('add-phone-tag', (args) => {
-      if (args && this.territory && this.territory.addresses) {
-        const { phoneId, notes } = args;
-        this.updatePhoneNotes({ territoryId: this.territory.id, phoneId, notes });
-      }
-    });
-    channel.bind('remove-phone-tag', (args) => {
-      if (args && this.territory && this.territory.addresses) {
-        const { phoneId, notes } = args;
-        this.updatePhoneNotes({ territoryId: this.territory.id, phoneId, notes });
-      }
-    });
-
     if (this.$route.query.addressId) {
       this.foundId = Number.parseInt(this.$route.query.addressId, 10);
       this.scrollToView();
@@ -95,8 +76,6 @@ export default {
     ...mapActions({
       resetNHRecords: 'territory/resetNHRecords',
       fetchPhone: 'address/fetchAddress',
-      updatePhoneNotes: 'territory/updatePhoneNotes',
-      setPhoneLastActivity: 'territory/setPhoneLastActivity',
       cancelFetchLastActivity: 'territory/cancelFetchLastActivity',
     }),
 

--- a/src/components/TerritoryAddresses.vue
+++ b/src/components/TerritoryAddresses.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="territory-addresses pb-5">
-    <SearchBar :search-text="'Search this territory'" @on-click="search" top="176px"></SearchBar>
-    <!-- <h3 v-if="territory.addresses.length === 0" class="w-100 text-center">
-      There are no addresses in this territory.
-    </h3> -->
+    <SearchBar :search-text="'Search this territory'" @on-click="search" top="135px"></SearchBar>
     <b-list-group>
       <swipe-list
         ref="list"

--- a/src/store/modules/address.js
+++ b/src/store/modules/address.js
@@ -118,7 +118,6 @@ export const address = {
     },
     FETCH_LAST_ACTIVITY_FAIL(state, exception) {
       state.error = exception;
-      console.error(FETCH_LAST_ACTIVITY_FAIL, exception);
     },
     FETCH_LAST_ACTIVITY_SUCCESS(state, lastActivity) {
       state.error = null;
@@ -215,7 +214,6 @@ export const address = {
         dispatch('territory/setAddressLastActivity', { addressId, lastActivity }, { root: true });
       } catch (e) {
         commit(FETCH_LAST_ACTIVITY_FAIL, e);
-        console.error(FETCH_LAST_ACTIVITY_FAIL, e);
       }
     },
 

--- a/src/store/modules/addresses.js
+++ b/src/store/modules/addresses.js
@@ -23,6 +23,7 @@ export const addresses = {
     search: [],
     logs: [],
     cancelTokens: {},
+    error: null,
   },
   getters: {
     dnc: state => state.dnc,
@@ -58,7 +59,7 @@ export const addresses = {
       state.logs = logs;
     },
     CHANGE_LOGS_FAIL(state, exception) {
-      console.error(CHANGE_LOGS_FAIL, exception);
+      state.error = exception;
     },
   },
   actions: {

--- a/src/store/modules/phone.js
+++ b/src/store/modules/phone.js
@@ -74,7 +74,6 @@ export const phone = {
     REMOVE_TAG_FAIL(state, error) { state.error = error; },
     FETCH_LAST_ACTIVITY_FAIL(state, exception) {
       state.error = exception;
-      console.error(FETCH_LAST_ACTIVITY_FAIL, exception);
     },
   },
 
@@ -120,7 +119,6 @@ export const phone = {
         dispatch('territory/setPhoneLastActivity', { phoneId, lastActivity }, { root: true });
       } catch (e) {
         commit(FETCH_LAST_ACTIVITY_FAIL, e);
-        console.error(`Unable to fetch last activity for phone id ${phoneId}.`, e);
       }
     },
 


### PR DESCRIPTION
The idea is to always have a fully updated territory object including addresses, phones, tags, and activity in order to omit having to refetch the large territory object from the server during a session.